### PR TITLE
Apply #270 to the Japanese document as well

### DIFF
--- a/docs/_advanced/ja_logging.md
+++ b/docs/_advanced/ja_logging.md
@@ -32,6 +32,7 @@ const app = new App({
 | メソッド      | パラメーター        | 戻り値の型    |
 |--------------|-------------------|-------------|
 | `setLevel()` | `level: LogLevel` | `void`      |
+| `getLevel()` | なし               | `string` (値は `error`, `warn`, `info`, `debug` のいずれか)  |
 | `setName()`  | `name: string`    | `void`      |
 | `debug()`    | `...msgs: any[]`  | `void`      |
 | `info()`     | `...msgs: any[]`  | `void`      |


### PR DESCRIPTION
###  Summary

This pull request just adds Japanese translation for #270

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).